### PR TITLE
feat: suppress implicit safe integer bounds in markdown docs

### DIFF
--- a/src/cli/__snapshots__/generate-markdown.test.ts.snap
+++ b/src/cli/__snapshots__/generate-markdown.test.ts.snap
@@ -6,7 +6,16 @@ exports[`generateMarkdown > generates complete markdown with all features 1`] = 
 - \`API_KEY\` (required)  
   Type: \`string\`  
   Description: Your API key for authentication  
-  Min length: \`32\`
+  Min length: \`32\`  
+  Max length: \`255\`
+
+- \`RATIO\` (required)  
+  Type: \`number\`  
+  Description: Cache hit ratio
+
+- \`SCORE_DELTA\` (required)  
+  Type: \`integer\`  
+  Description: Score adjustment, negative values reduce score
 
 ## App
 
@@ -18,7 +27,7 @@ exports[`generateMarkdown > generates complete markdown with all features 1`] = 
 ## App Server
 
 - \`PORT\` (optional)  
-  Type: \`number\`  
+  Type: \`integer\`  
   Description: Server port  
   Min value: \`1024\`  
   Max value: \`65535\`  

--- a/src/cli/generate-markdown.test.ts
+++ b/src/cli/generate-markdown.test.ts
@@ -17,7 +17,11 @@ describe('generateMarkdown', () => {
       {
         envName: 'API_KEY',
         path: [],
-        schema: z.string().min(32).max(255).describe('Your API key for authentication'),
+        schema: z
+          .string()
+          .min(32)
+          .max(255)
+          .describe('Your API key for authentication'),
       },
       {
         envName: 'RATIO',
@@ -27,7 +31,10 @@ describe('generateMarkdown', () => {
       {
         envName: 'SCORE_DELTA',
         path: [],
-        schema: z.number().int().describe('Score adjustment, negative values reduce score'),
+        schema: z
+          .number()
+          .int()
+          .describe('Score adjustment, negative values reduce score'),
       },
       {
         envName: 'LOG_LEVEL',

--- a/src/cli/generate-markdown.test.ts
+++ b/src/cli/generate-markdown.test.ts
@@ -17,7 +17,17 @@ describe('generateMarkdown', () => {
       {
         envName: 'API_KEY',
         path: [],
-        schema: z.string().min(32).describe('Your API key for authentication'),
+        schema: z.string().min(32).max(255).describe('Your API key for authentication'),
+      },
+      {
+        envName: 'RATIO',
+        path: [],
+        schema: z.number().describe('Cache hit ratio'),
+      },
+      {
+        envName: 'SCORE_DELTA',
+        path: [],
+        schema: z.number().int().describe('Score adjustment, negative values reduce score'),
       },
       {
         envName: 'LOG_LEVEL',
@@ -29,6 +39,7 @@ describe('generateMarkdown', () => {
         path: ['app', 'server'],
         schema: z
           .number()
+          .int()
           .min(1024)
           .max(65535)
           .default(3000)

--- a/src/cli/generate-markdown.ts
+++ b/src/cli/generate-markdown.ts
@@ -72,13 +72,19 @@ export const generateMarkdown = (
       }
       if (
         schema.minimum !== undefined &&
-        !(schema.type === 'integer' && schema.minimum === Number.MIN_SAFE_INTEGER)
+        !(
+          schema.type === 'integer' &&
+          schema.minimum === Number.MIN_SAFE_INTEGER
+        )
       ) {
         line += `  \n  Min value: \`${schema.minimum}\``;
       }
       if (
         schema.maximum !== undefined &&
-        !(schema.type === 'integer' && schema.maximum === Number.MAX_SAFE_INTEGER)
+        !(
+          schema.type === 'integer' &&
+          schema.maximum === Number.MAX_SAFE_INTEGER
+        )
       ) {
         line += `  \n  Max value: \`${schema.maximum}\``;
       }

--- a/src/cli/generate-markdown.ts
+++ b/src/cli/generate-markdown.ts
@@ -70,10 +70,16 @@ export const generateMarkdown = (
       if (schema.pattern) {
         line += `  \n  Pattern: \`${schema.pattern}\``;
       }
-      if (schema.minimum !== undefined) {
+      if (
+        schema.minimum !== undefined &&
+        !(schema.type === 'integer' && schema.minimum === Number.MIN_SAFE_INTEGER)
+      ) {
         line += `  \n  Min value: \`${schema.minimum}\``;
       }
-      if (schema.maximum !== undefined) {
+      if (
+        schema.maximum !== undefined &&
+        !(schema.type === 'integer' && schema.maximum === Number.MAX_SAFE_INTEGER)
+      ) {
         line += `  \n  Max value: \`${schema.maximum}\``;
       }
       if (schema.minLength !== undefined) {


### PR DESCRIPTION
## Suppress implicit safe integer bounds in generated docs

### Problem

Zod automatically assigns Number.MIN_SAFE_INTEGER and Number.MAX_SAFE_INTEGER as implicit bounds for integer fields when no explicit min or max is defined.

These default bounds were being rendered in the generated markdown documentation as “Min value” and “Max value”, even though they do not represent meaningful user-defined constraints. This added unnecessary noise to the output.

### Solution

Filter out these implicit Zod defaults during documentation generation.