### PR TITLE
fix(generate-markdown): display output type for transform schemas

### DIFF
--- a/src/cli/__snapshots__/generate-markdown.test.ts.snap
+++ b/src/cli/__snapshots__/generate-markdown.test.ts.snap
@@ -43,5 +43,12 @@ exports[`generateMarkdown > generates complete markdown with all features 1`] = 
 - \`DB_HOST\` (required)  
   Type: \`string\`  
   Description: Database host address
+
+## Feature
+
+- \`FEATURE_ENABLED\` (optional)  
+  Type: \`boolean\`  
+  Description: Enable feature flag  
+  Default: \`false\`
 "
 `;

--- a/src/cli/generate-markdown.test.ts
+++ b/src/cli/generate-markdown.test.ts
@@ -5,7 +5,8 @@ import { generateMarkdown } from './generate-markdown.ts';
 
 const stringToNumberSchema = <T extends z.ZodTypeAny>(schema: T) =>
   z.preprocess(
-    (val): number | undefined => (val === undefined || val === '' ? undefined : Number(val)),
+    (val): number | undefined =>
+      val === undefined || val === '' ? undefined : Number(val),
     schema,
   );
 

--- a/src/cli/generate-markdown.test.ts
+++ b/src/cli/generate-markdown.test.ts
@@ -3,6 +3,12 @@ import { z } from 'zod';
 import type { ExtractedEnvvar } from './extract-envvars.ts';
 import { generateMarkdown } from './generate-markdown.ts';
 
+const stringToNumberSchema = <T extends z.ZodTypeAny>(schema: T) =>
+  z.preprocess(
+    (val): number | undefined => (val === undefined || val === '' ? undefined : Number(val)),
+    schema,
+  );
+
 describe('generateMarkdown', () => {
   it('handles empty array of environment variables', () => {
     const extractedEnvvars: ExtractedEnvvar[] = [];
@@ -26,15 +32,14 @@ describe('generateMarkdown', () => {
       {
         envName: 'RATIO',
         path: [],
-        schema: z.number().describe('Cache hit ratio'),
+        schema: stringToNumberSchema(z.number()).describe('Cache hit ratio'),
       },
       {
         envName: 'SCORE_DELTA',
         path: [],
-        schema: z
-          .number()
-          .int()
-          .describe('Score adjustment, negative values reduce score'),
+        schema: stringToNumberSchema(z.number().int()).describe(
+          'Score adjustment, negative values reduce score',
+        ),
       },
       {
         envName: 'LOG_LEVEL',
@@ -44,13 +49,9 @@ describe('generateMarkdown', () => {
       {
         envName: 'PORT',
         path: ['app', 'server'],
-        schema: z
-          .number()
-          .int()
-          .min(1024)
-          .max(65535)
-          .default(3000)
-          .describe('Server port'),
+        schema: stringToNumberSchema(
+          z.number().int().min(1024).max(65535).default(3000),
+        ).describe('Server port'),
       },
       {
         envName: 'HOST',
@@ -66,6 +67,11 @@ describe('generateMarkdown', () => {
         envName: 'DB_HOST',
         path: ['database'],
         schema: z.string().describe('Database host address'),
+      },
+      {
+        envName: 'FEATURE_ENABLED',
+        path: ['feature'],
+        schema: z.stringbool().default(false).describe('Enable feature flag'),
       },
     ];
 

--- a/src/cli/generate-markdown.ts
+++ b/src/cli/generate-markdown.ts
@@ -33,16 +33,19 @@ export const generateMarkdown = (
     }
 
     for (const envvar of envvars) {
-      const schema = envvar.schema['~standard'].jsonSchema.input({
+      const jsonSchemaOptions = {
         target: 'openapi-3.0',
         libraryOptions: {
           unrepresentable: 'any',
         },
-      });
+      };
 
-      const mappedType = Array.isArray(schema.anyOf)
-        ? schema.anyOf.map((schema) => schema.type)
-        : schema.type;
+      const inputSchema = envvar.schema['~standard'].jsonSchema.input(jsonSchemaOptions);
+      const outputSchema = envvar.schema['~standard'].jsonSchema.output(jsonSchemaOptions);
+
+      const mappedType = Array.isArray(outputSchema.anyOf)
+        ? outputSchema.anyOf.map(({ type }) => type)
+        : outputSchema.type ?? inputSchema.type;
 
       const type = Array.isArray(mappedType)
         ? mappedType.map((type) => `\`${type}\``).join(' | ')
@@ -55,47 +58,47 @@ export const generateMarkdown = (
 
       line += `  \n  Type: ${type}`;
 
-      if (schema.description) {
-        line += `  \n  Description: ${schema.description}`;
+      if (inputSchema.description) {
+        line += `  \n  Description: ${inputSchema.description}`;
       }
 
-      if (Array.isArray(schema.enum)) {
-        const enumValues = schema.enum.map((v) => `\`${v}\``).join(' | ');
+      if (Array.isArray(inputSchema.enum)) {
+        const enumValues = inputSchema.enum.map((v) => `\`${v}\``).join(' | ');
         line += `  \n  Supported values: ${enumValues}`;
       }
 
-      if (schema.format) {
-        line += `  \n  Format: \`${schema.format}\``;
+      if (inputSchema.format) {
+        line += `  \n  Format: \`${inputSchema.format}\``;
       }
-      if (schema.pattern) {
-        line += `  \n  Pattern: \`${schema.pattern}\``;
-      }
-      if (
-        schema.minimum !== undefined &&
-        !(
-          schema.type === 'integer' &&
-          schema.minimum === Number.MIN_SAFE_INTEGER
-        )
-      ) {
-        line += `  \n  Min value: \`${schema.minimum}\``;
+      if (inputSchema.pattern) {
+        line += `  \n  Pattern: \`${inputSchema.pattern}\``;
       }
       if (
-        schema.maximum !== undefined &&
+        inputSchema.minimum !== undefined &&
         !(
-          schema.type === 'integer' &&
-          schema.maximum === Number.MAX_SAFE_INTEGER
+          inputSchema.type === 'integer' &&
+          inputSchema.minimum === Number.MIN_SAFE_INTEGER
         )
       ) {
-        line += `  \n  Max value: \`${schema.maximum}\``;
+        line += `  \n  Min value: \`${inputSchema.minimum}\``;
       }
-      if (schema.minLength !== undefined) {
-        line += `  \n  Min length: \`${schema.minLength}\``;
+      if (
+        inputSchema.maximum !== undefined &&
+        !(
+          inputSchema.type === 'integer' &&
+          inputSchema.maximum === Number.MAX_SAFE_INTEGER
+        )
+      ) {
+        line += `  \n  Max value: \`${inputSchema.maximum}\``;
       }
-      if (schema.maxLength !== undefined) {
-        line += `  \n  Max length: \`${schema.maxLength}\``;
+      if (inputSchema.minLength !== undefined) {
+        line += `  \n  Min length: \`${inputSchema.minLength}\``;
       }
-      if (schema.default !== undefined) {
-        line += `  \n  Default: \`${schema.default}\``;
+      if (inputSchema.maxLength !== undefined) {
+        line += `  \n  Max length: \`${inputSchema.maxLength}\``;
+      }
+      if (inputSchema.default !== undefined) {
+        line += `  \n  Default: \`${inputSchema.default}\``;
       }
 
       lines.push(line, '');

--- a/src/cli/generate-markdown.ts
+++ b/src/cli/generate-markdown.ts
@@ -40,12 +40,14 @@ export const generateMarkdown = (
         },
       };
 
-      const inputSchema = envvar.schema['~standard'].jsonSchema.input(jsonSchemaOptions);
-      const outputSchema = envvar.schema['~standard'].jsonSchema.output(jsonSchemaOptions);
+      const inputSchema =
+        envvar.schema['~standard'].jsonSchema.input(jsonSchemaOptions);
+      const outputSchema =
+        envvar.schema['~standard'].jsonSchema.output(jsonSchemaOptions);
 
       const mappedType = Array.isArray(outputSchema.anyOf)
         ? outputSchema.anyOf.map(({ type }) => type)
-        : outputSchema.type ?? inputSchema.type;
+        : (outputSchema.type ?? inputSchema.type);
 
       const type = Array.isArray(mappedType)
         ? mappedType.map((type) => `\`${type}\``).join(' | ')


### PR DESCRIPTION
- Use outputSchema.type (with inputSchema.type as fallback) when rendering the Type: field in generated markdown docs, so transform-based schemas like z.stringbool() display their output type (boolean) rather than their input type (string)
- Add z.stringbool().default(false) test case to the markdown generation test
- Fix z.number() test schemas to use stringToNumberSchema / z.coerce.number() — env vars are always string | undefined, bare z.number() schemas were misleading
